### PR TITLE
[#34] Phase 4: 割引設定機能の実装

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@radix-ui/react-label": "^2.1.7",
+        "@radix-ui/react-radio-group": "^1.3.8",
         "@radix-ui/react-select": "^2.2.6",
         "@radix-ui/react-slot": "^1.2.3",
         "@radix-ui/react-switch": "^1.2.6",
@@ -1330,6 +1331,30 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-presence": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.5.tgz",
+      "integrity": "sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-primitive": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
@@ -1337,6 +1362,69 @@
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-radio-group": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-radio-group/-/react-radio-group-1.3.8.tgz",
+      "integrity": "sha512-VBKYIYImA5zsxACdisNQ3BjCBfmbGH3kQlnFVqlWU4tXwjy7cGX8ta80BcrO+WJXIn5iBylEH3K6ZTlee//lgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-roving-focus": "1.1.11",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-roving-focus": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.11.tgz",
+      "integrity": "sha512-7A6S9jSgm/S+7MdtNDSb+IU859vQqJ/QAtcYQcfFC6W8RS4IxIZDldLR0xqCFZ6DCyrQLjLPsxtTNch5jVA4lA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
       },
       "peerDependencies": {
         "@types/react": "*",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@radix-ui/react-label": "^2.1.7",
+    "@radix-ui/react-radio-group": "^1.3.8",
     "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-slot": "^1.2.3",
     "@radix-ui/react-switch": "^1.2.6",

--- a/src/app/settings/discounts/page.tsx
+++ b/src/app/settings/discounts/page.tsx
@@ -1,0 +1,244 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { MainLayout } from "@/components/layout/main-layout"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Switch } from "@/components/ui/switch"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { Plus, Trash2 } from "lucide-react"
+import {
+  getAllDiscounts,
+  createDiscount,
+  deleteDiscount,
+  toggleDiscountEnabled
+} from "@/lib/discounts"
+import { validateDiscountValue } from "@/types/discount"
+import type { DiscountSetting, DiscountType } from "@/types/discount"
+import { showSuccess, showError } from "@/lib/toast"
+
+const TEST_USER_ID = "test-user-id"
+
+interface NewDiscount {
+  shopName: string
+  discountType: DiscountType
+  discountValue: string
+}
+
+export default function DiscountsPage() {
+  const [discounts, setDiscounts] = useState<DiscountSetting[]>([])
+  const [loading, setLoading] = useState(true)
+  const [newDiscount, setNewDiscount] = useState<NewDiscount>({
+    shopName: "",
+    discountType: "percentage",
+    discountValue: ""
+  })
+
+  useEffect(() => {
+    loadDiscounts()
+  }, [])
+
+  const loadDiscounts = async () => {
+    try {
+      setLoading(true)
+      const data = await getAllDiscounts(TEST_USER_ID)
+      setDiscounts(data)
+    } catch (error) {
+      console.error("割引設定読み込みエラー:", error)
+      showError("割引設定の読み込みに失敗しました")
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const handleAdd = async () => {
+    const value = parseFloat(newDiscount.discountValue)
+
+    if (!newDiscount.shopName) {
+      showError("ショップ名を入力してください")
+      return
+    }
+
+    if (isNaN(value) || !validateDiscountValue(newDiscount.discountType, value)) {
+      showError("正しい割引値を入力してください")
+      return
+    }
+
+    const result = await createDiscount(TEST_USER_ID, {
+      shopName: newDiscount.shopName,
+      discountType: newDiscount.discountType,
+      discountValue: value
+    })
+
+    if (result) {
+      showSuccess("割引設定を追加しました")
+      setNewDiscount({ shopName: "", discountType: "percentage", discountValue: "" })
+      loadDiscounts()
+    } else {
+      showError("割引設定の追加に失敗しました")
+    }
+  }
+
+  const handleDelete = async (shopName: string) => {
+    if (!confirm(`${shopName}の割引設定を削除しますか？`)) {
+      return
+    }
+
+    const result = await deleteDiscount(TEST_USER_ID, shopName)
+
+    if (result) {
+      showSuccess("割引設定を削除しました")
+      loadDiscounts()
+    } else {
+      showError("割引設定の削除に失敗しました")
+    }
+  }
+
+  const handleToggle = async (shopName: string, isEnabled: boolean) => {
+    const result = await toggleDiscountEnabled(TEST_USER_ID, shopName, isEnabled)
+
+    if (result) {
+      showSuccess(`割引設定を${isEnabled ? "有効" : "無効"}にしました`)
+      loadDiscounts()
+    } else {
+      showError("割引設定の切り替えに失敗しました")
+    }
+  }
+
+  return (
+    <MainLayout>
+      <div className="space-y-6">
+        <div>
+          <h1 className="text-3xl font-bold">割引設定</h1>
+          <p className="text-muted-foreground">
+            ショップごとの割引設定を管理します
+          </p>
+        </div>
+
+        {/* 新規追加フォーム */}
+        <div className="rounded-lg border bg-card p-6">
+          <h3 className="font-semibold mb-4">新しい割引設定を追加</h3>
+          <div className="grid gap-4 md:grid-cols-4">
+            <div className="space-y-2">
+              <Label htmlFor="shopName">ショップ名</Label>
+              <Input
+                id="shopName"
+                placeholder="例: VT公式"
+                value={newDiscount.shopName}
+                onChange={(e) => setNewDiscount({ ...newDiscount, shopName: e.target.value })}
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="discountType">割引タイプ</Label>
+              <Select
+                value={newDiscount.discountType}
+                onValueChange={(value) =>
+                  setNewDiscount({ ...newDiscount, discountType: value as DiscountType })
+                }
+              >
+                <SelectTrigger id="discountType">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="percentage">パーセンテージ (%)</SelectItem>
+                  <SelectItem value="fixed">固定額 (円)</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="discountValue">
+                割引値 {newDiscount.discountType === "percentage" ? "(%)" : "(円)"}
+              </Label>
+              <Input
+                id="discountValue"
+                type="number"
+                min="0"
+                max={newDiscount.discountType === "percentage" ? "100" : undefined}
+                placeholder={newDiscount.discountType === "percentage" ? "例: 10" : "例: 500"}
+                value={newDiscount.discountValue}
+                onChange={(e) => setNewDiscount({ ...newDiscount, discountValue: e.target.value })}
+              />
+            </div>
+
+            <div className="flex items-end">
+              <Button onClick={handleAdd} className="w-full">
+                <Plus className="h-4 w-4 mr-2" />
+                追加
+              </Button>
+            </div>
+          </div>
+        </div>
+
+        {/* 割引設定一覧 */}
+        <div className="rounded-lg border bg-card p-6">
+          <h3 className="font-semibold mb-4">割引設定一覧</h3>
+          {loading ? (
+            <p className="text-center py-8 text-muted-foreground">読み込み中...</p>
+          ) : discounts.length === 0 ? (
+            <p className="text-center py-8 text-muted-foreground">
+              割引設定がありません
+            </p>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>ショップ名</TableHead>
+                  <TableHead>割引タイプ</TableHead>
+                  <TableHead>割引値</TableHead>
+                  <TableHead>有効/無効</TableHead>
+                  <TableHead className="text-right">操作</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {discounts.map((discount) => (
+                  <TableRow key={discount.id}>
+                    <TableCell className="font-medium">{discount.shopName}</TableCell>
+                    <TableCell>
+                      {discount.discountType === "percentage" ? "パーセンテージ" : "固定額"}
+                    </TableCell>
+                    <TableCell>
+                      {discount.discountValue}
+                      {discount.discountType === "percentage" ? "%" : "円"}
+                    </TableCell>
+                    <TableCell>
+                      <Switch
+                        checked={discount.isEnabled}
+                        onCheckedChange={(checked) => handleToggle(discount.shopName, checked)}
+                      />
+                    </TableCell>
+                    <TableCell className="text-right">
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => handleDelete(discount.shopName)}
+                      >
+                        <Trash2 className="h-4 w-4" />
+                      </Button>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+        </div>
+      </div>
+    </MainLayout>
+  )
+}

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -55,6 +55,10 @@ const navigation = [
     name: "設定",
     href: "/settings",
     icon: Settings,
+    children: [
+      { name: "全体設定", href: "/settings" },
+      { name: "割引設定", href: "/settings/discounts" },
+    ],
   },
 ]
 

--- a/src/lib/discounts.ts
+++ b/src/lib/discounts.ts
@@ -1,0 +1,204 @@
+/**
+ * 割引設定ユーティリティ
+ */
+
+import { supabase } from "./supabase"
+import type { DiscountSetting, DiscountSettingCreate, DiscountSettingUpdate } from "@/types/discount"
+import type { ShopDiscount } from "@/types/database"
+
+/**
+ * 全ての割引設定を取得
+ */
+export async function getAllDiscounts(userId: string): Promise<DiscountSetting[]> {
+  try {
+    const { data, error } = await supabase
+      .from("shop_discounts")
+      .select("*")
+      .eq("user_id", userId)
+      .order("shop_name", { ascending: true })
+
+    if (error) {
+      console.error("割引設定取得エラー:", error)
+      return []
+    }
+
+    return (data as ShopDiscount[]).map(mapToDiscountSetting)
+  } catch (error) {
+    console.error("割引設定取得エラー:", error)
+    return []
+  }
+}
+
+/**
+ * ショップ名で割引設定を取得
+ */
+export async function getDiscountByShop(
+  userId: string,
+  shopName: string
+): Promise<DiscountSetting | null> {
+  try {
+    const { data, error } = await supabase
+      .from("shop_discounts")
+      .select("*")
+      .eq("user_id", userId)
+      .eq("shop_name", shopName)
+      .single()
+
+    if (error) {
+      if (error.code === "PGRST116") {
+        // データが見つからない場合はnullを返す
+        return null
+      }
+      console.error("割引設定取得エラー:", error)
+      return null
+    }
+
+    return mapToDiscountSetting(data as ShopDiscount)
+  } catch (error) {
+    console.error("割引設定取得エラー:", error)
+    return null
+  }
+}
+
+/**
+ * 割引設定を作成
+ */
+export async function createDiscount(
+  userId: string,
+  discount: DiscountSettingCreate
+): Promise<DiscountSetting | null> {
+  try {
+    const { data, error } = await supabase
+      .from("shop_discounts")
+      .insert({
+        user_id: userId,
+        shop_name: discount.shopName,
+        discount_type: discount.discountType,
+        discount_value: discount.discountValue,
+        is_enabled: discount.isEnabled ?? true
+      })
+      .select()
+      .single()
+
+    if (error) {
+      console.error("割引設定作成エラー:", error)
+      return null
+    }
+
+    return mapToDiscountSetting(data as ShopDiscount)
+  } catch (error) {
+    console.error("割引設定作成エラー:", error)
+    return null
+  }
+}
+
+/**
+ * 割引設定を更新
+ */
+export async function updateDiscount(
+  userId: string,
+  shopName: string,
+  updates: DiscountSettingUpdate
+): Promise<DiscountSetting | null> {
+  try {
+    const updateData: {
+      discount_type?: "percentage" | "fixed"
+      discount_value?: number
+      is_enabled?: boolean
+    } = {}
+
+    if (updates.discountType !== undefined) {
+      updateData.discount_type = updates.discountType
+    }
+    if (updates.discountValue !== undefined) {
+      updateData.discount_value = updates.discountValue
+    }
+    if (updates.isEnabled !== undefined) {
+      updateData.is_enabled = updates.isEnabled
+    }
+
+    const { data, error } = await supabase
+      .from("shop_discounts")
+      .update(updateData)
+      .eq("user_id", userId)
+      .eq("shop_name", shopName)
+      .select()
+      .single()
+
+    if (error) {
+      console.error("割引設定更新エラー:", error)
+      return null
+    }
+
+    return mapToDiscountSetting(data as ShopDiscount)
+  } catch (error) {
+    console.error("割引設定更新エラー:", error)
+    return null
+  }
+}
+
+/**
+ * 割引設定を削除
+ */
+export async function deleteDiscount(userId: string, shopName: string): Promise<boolean> {
+  try {
+    const { error } = await supabase
+      .from("shop_discounts")
+      .delete()
+      .eq("user_id", userId)
+      .eq("shop_name", shopName)
+
+    if (error) {
+      console.error("割引設定削除エラー:", error)
+      return false
+    }
+
+    return true
+  } catch (error) {
+    console.error("割引設定削除エラー:", error)
+    return false
+  }
+}
+
+/**
+ * 割引設定を有効/無効に切り替え
+ */
+export async function toggleDiscountEnabled(
+  userId: string,
+  shopName: string,
+  isEnabled: boolean
+): Promise<boolean> {
+  try {
+    const { error } = await supabase
+      .from("shop_discounts")
+      .update({ is_enabled: isEnabled })
+      .eq("user_id", userId)
+      .eq("shop_name", shopName)
+
+    if (error) {
+      console.error("割引設定切り替えエラー:", error)
+      return false
+    }
+
+    return true
+  } catch (error) {
+    console.error("割引設定切り替えエラー:", error)
+    return false
+  }
+}
+
+/**
+ * データベース型をアプリケーション型にマッピング
+ */
+function mapToDiscountSetting(data: ShopDiscount): DiscountSetting {
+  return {
+    id: data.id,
+    userId: data.user_id,
+    shopName: data.shop_name,
+    discountType: data.discount_type,
+    discountValue: data.discount_value,
+    isEnabled: data.is_enabled,
+    createdAt: data.created_at,
+    updatedAt: data.updated_at
+  }
+}

--- a/src/types/discount.ts
+++ b/src/types/discount.ts
@@ -1,0 +1,84 @@
+/**
+ * 割引設定の型定義
+ */
+
+import { z } from "zod"
+
+// 割引タイプ
+export type DiscountType = "percentage" | "fixed"
+
+// 割引設定
+export interface DiscountSetting {
+  id: string
+  userId: string
+  shopName: string
+  discountType: DiscountType
+  discountValue: number
+  isEnabled: boolean
+  createdAt: string
+  updatedAt: string
+}
+
+// 割引設定作成用
+export interface DiscountSettingCreate {
+  shopName: string
+  discountType: DiscountType
+  discountValue: number
+  isEnabled?: boolean
+}
+
+// 割引設定更新用
+export interface DiscountSettingUpdate {
+  discountType?: DiscountType
+  discountValue?: number
+  isEnabled?: boolean
+}
+
+// バリデーションスキーマ
+export const discountSettingSchema = z.object({
+  shopName: z.string().min(1, "ショップ名を入力してください"),
+  discountType: z.enum(["percentage", "fixed"], {
+    errorMap: () => ({ message: "割引タイプを選択してください" })
+  }),
+  discountValue: z.number()
+    .min(0, "割引値は0以上である必要があります")
+    .refine((val) => val >= 0, {
+      message: "割引値は0以上である必要があります"
+    }),
+  isEnabled: z.boolean().optional()
+})
+
+export const discountSettingUpdateSchema = z.object({
+  discountType: z.enum(["percentage", "fixed"]).optional(),
+  discountValue: z.number().min(0).optional(),
+  isEnabled: z.boolean().optional()
+})
+
+// バリデーション関数
+export function validateDiscountValue(type: DiscountType, value: number): boolean {
+  if (value < 0) return false
+  if (type === "percentage" && value > 100) return false
+  return true
+}
+
+// 割引計算
+export function calculateDiscount(
+  price: number,
+  discountType: DiscountType,
+  discountValue: number
+): number {
+  if (discountType === "percentage") {
+    return price * (discountValue / 100)
+  }
+  return discountValue
+}
+
+// 割引適用後の価格計算
+export function applyDiscount(
+  price: number,
+  discountType: DiscountType,
+  discountValue: number
+): number {
+  const discount = calculateDiscount(price, discountType, discountValue)
+  return Math.max(0, price - discount)
+}


### PR DESCRIPTION
## 概要
ショップ別の割引設定機能を実装し、利益計算に反映させました。

## 変更内容
### 1. 割引設定の型定義とユーティリティ (src/types/discount.ts, src/lib/discounts.ts)
- DiscountSetting型定義（パーセンテージ/固定額）
- Zodバリデーションスキーマ
- 割引計算・適用関数
- Supabase CRUD操作（取得、作成、更新、削除、有効/無効切り替え）

### 2. 割引設定ページUI (src/app/settings/discounts/page.tsx)
- `/settings/discounts` ページ作成
- ショップ名入力、割引タイプ選択（パーセンテージ/固定額）
- 割引値入力、有効/無効切り替え
- 割引設定一覧表示（追加・削除機能）
- サイドバーに「割引設定」メニュー追加

### 3. 利益計算への反映 (src/lib/dashboard.ts)
- getDashboardSummary: 割引設定を適用した利益集計
- getShopStats: ショップ別統計に割引を反映
- 有効な割引のみを適用

## テスト内容
- [x] 割引設定ページが表示される
- [x] ショップごとに割引設定が追加できる
- [x] パーセンテージと固定額の両方に対応
- [x] 有効/無効の切り替えができる
- [x] 設定削除ができる
- [x] ダッシュボード集計に割引が反映される

## チェックリスト
- [x] 割引設定型定義とユーティリティを実装
- [x] 割引設定ページUIを実装
- [x] ダッシュボード集計に割引を反映
- [x] TypeScriptエラーなし（割引設定関連）
- [x] コミットメッセージ規約に準拠

Close #34