### PR TITLE
[#55] DHCスクレイピング機能の修正

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -9,6 +9,12 @@ const nextConfig: NextConfig = {
         port: "",
         pathname: "/**",
       },
+      {
+        protocol: "https",
+        hostname: "www.dhc.co.jp",
+        port: "",
+        pathname: "/**",
+      },
     ],
   },
 };

--- a/src/hooks/official/useOfficialBrandPage.ts
+++ b/src/hooks/official/useOfficialBrandPage.ts
@@ -30,12 +30,13 @@ export function useOfficialBrandPage({
 
     setIsRefreshing(true)
     try {
-      const response = await fetch(`/api/scraping/${brandConfig.name}`, {
+      const response = await fetch(`/api/scrape/${brandConfig.name}`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
         },
         body: JSON.stringify({
+          userId,
           headless: true,
           timeout: 30000
         })

--- a/src/hooks/official/useOfficialPage.ts
+++ b/src/hooks/official/useOfficialPage.ts
@@ -15,12 +15,13 @@ export function useOfficialPage({ userId }: UseOfficialPageOptions) {
   const handleRefresh = async () => {
     setIsRefreshing(true)
     try {
-      const response = await fetch("/api/scraping/vt", {
+      const response = await fetch("/api/scrape/vt", {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
         },
         body: JSON.stringify({
+          userId,
           headless: true,
           timeout: 30000
         })

--- a/src/lib/scraper.ts
+++ b/src/lib/scraper.ts
@@ -33,6 +33,11 @@ export class BaseScraper {
    * ブラウザを起動
    */
   async launch(options: ScraperOptions = {}): Promise<void> {
+    // 既に起動済みの場合はスキップ
+    if (this.browser) {
+      return
+    }
+
     try {
       const launchOptions: LaunchOptions = {
         headless: options.headless ?? true,


### PR DESCRIPTION
## 概要
DHCスクレイピング処理で発生していた複数の問題を修正

## 変更内容
- APIエンドポイントパスを/api/scrape/dhcに統一
- DHCスクレイパーのセレクタを実際のHTML構造に合わせて修正
- ページ読み込み戦略をdomcontentloadedに変更
- DHCのハッシュ形式ページネーション(#p-2,s-60...)に対応
- Next.js画像設定にwww.dhc.co.jpを追加
- ブラウザ重複起動防止ロジックを追加

## テスト内容
- 全8カテゴリで複数ページの商品を正常に取得
- 画像が正しく表示される
- 最終ページで正しく停止する

## チェックリスト
- [x] TypeScriptエラーなし
- [x] 動作確認済み
- [x] コミットを論理的な単位で分割

Fixes #55