### PR TITLE
[#63] 楽天商品の重複判定とショップ設定編集機能の修正

### DIFF
--- a/src/app/rakuten/[brand]/page.tsx
+++ b/src/app/rakuten/[brand]/page.tsx
@@ -3,138 +3,198 @@
 /**
  * 楽天ブランドページ
  * 動的ルート: /rakuten/[brand]
+ * データベースから設定を読み込んで表示
  */
 
-import { useParams } from "next/navigation"
+import { useParams, useRouter } from "next/navigation"
+import { useState, useEffect } from "react"
 import { Sidebar } from "@/components/layout/Sidebar"
 import { Button } from "@/components/ui/Button"
-import { Input } from "@/components/ui/Input"
-import { Card } from "@/components/ui/Card"
-import { PaginatedProductTable } from "@/components/products/PaginatedProductTable"
-import { useRakutenPage } from "@/hooks/rakuten/useRakutenPage"
+import { ProductTable } from "@/components/products/ProductTable"
+import { supabase } from "@/lib/supabase"
+import type { Database } from "@/types/database"
 
-// ブランド設定
-const BRAND_CONFIG: Record<string, {
-  displayName: string
-  shopCode?: string
-  genreId?: string
-  defaultKeyword?: string
-}> = {
-  muji: {
-    displayName: "無印良品",
-    defaultKeyword: "無印良品"
-  },
-  vt: {
-    displayName: "VT Cosmetics",
-    defaultKeyword: "VT Cosmetics"
-  },
-  innisfree: {
-    displayName: "innisfree",
-    defaultKeyword: "innisfree"
-  }
-}
+type RakutenShop = Database["public"]["Tables"]["rakuten_shops"]["Row"]
 
 export default function RakutenBrandPage() {
   const params = useParams()
+  const router = useRouter()
   const brand = params.brand as string
 
-  const brandConfig = BRAND_CONFIG[brand]
+  const [shopConfig, setShopConfig] = useState<RakutenShop | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [updating, setUpdating] = useState(false)
+  const [refreshKey, setRefreshKey] = useState(0)
+  const [toast, setToast] = useState<{ message: string; type: "success" | "error" | "warning" } | null>(null)
 
-  // カスタムフックから全てのロジックを取得
-  const {
-    keyword,
-    shopCode,
-    genreId,
-    loading,
-    refreshKey,
-    setKeyword,
-    setShopCode,
-    setGenreId,
-    handleSearch
-  } = useRakutenPage({
-    defaultKeyword: brandConfig?.defaultKeyword || "",
-    defaultShopCode: brandConfig?.shopCode || "",
-    defaultGenreId: brandConfig?.genreId || "",
-    shopName: brandConfig?.displayName || ""
-  })
+  // トースト表示関数
+  const showToast = (message: string, type: "success" | "error" | "warning") => {
+    setToast({ message, type })
+    setTimeout(() => setToast(null), 4000)
+  }
 
-  if (!brandConfig) {
+  // ショップ設定を読み込み
+  useEffect(() => {
+    const loadShopConfig = async () => {
+      const { data, error } = await supabase
+        .from("rakuten_shops")
+        .select("*")
+        .eq("shop_id", brand)
+        .eq("is_active", true)
+        .single()
+
+      if (error || !data) {
+        // ショップが見つからない場合は管理ページへリダイレクト
+        router.push("/rakuten")
+        return
+      }
+
+      setShopConfig(data)
+      setLoading(false)
+    }
+
+    loadShopConfig()
+  }, [brand, router])
+
+  // 商品データ更新処理
+  const handleUpdate = async () => {
+    if (!shopConfig) return
+
+    setUpdating(true)
+
+    try {
+      const requestBody: Record<string, unknown> = {
+        shopCode: shopConfig.shop_code,
+        genreId: shopConfig.genre_id,
+        shopName: shopConfig.display_name,
+        hits: 30,
+        page: 1
+      }
+
+      // キーワードが設定されている場合のみ追加
+      if (shopConfig.default_keyword) {
+        requestBody.keyword = shopConfig.default_keyword
+      }
+
+      const response = await fetch("/api/rakuten/search", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(requestBody)
+      })
+
+      const result = await response.json()
+
+      if (result.success) {
+        const { savedCount, skippedCount } = result.data
+        if (savedCount > 0) {
+          showToast(
+            `${savedCount}件の新規商品を追加しました${skippedCount > 0 ? `（重複: ${skippedCount}件）` : ""}`,
+            "success"
+          )
+        } else if (skippedCount > 0) {
+          showToast(`すべて重複商品でした（${skippedCount}件）`, "warning")
+        } else {
+          showToast("取得できる商品がありませんでした", "warning")
+        }
+        // テーブルをリフレッシュ
+        setRefreshKey(prev => prev + 1)
+      } else {
+        showToast(`商品データの取得に失敗しました: ${result.message}`, "error")
+      }
+    } catch (error) {
+      showToast("商品データの取得に失敗しました", "error")
+    } finally {
+      setUpdating(false)
+    }
+  }
+
+  if (loading) {
     return (
       <div className="flex h-screen">
         <Sidebar />
         <main className="flex-1 overflow-y-auto p-6">
           <div className="max-w-7xl mx-auto">
-            <h1 className="text-3xl font-bold text-red-600">ブランドが見つかりません</h1>
+            <p className="text-gray-500">読み込み中...</p>
           </div>
         </main>
       </div>
     )
   }
 
+  if (!shopConfig) {
+    return null
+  }
+
   return (
     <div className="flex h-screen">
       <Sidebar />
-      <main className="flex-1 overflow-y-auto p-6">
-        <div className="max-w-7xl mx-auto space-y-6">
-          <div>
-            <h1 className="text-3xl font-bold">{brandConfig.displayName}</h1>
-            <p className="text-muted-foreground mt-2">
-              楽天市場から{brandConfig.displayName}の商品を検索・管理
-            </p>
-          </div>
-
-          {/* 検索フォーム */}
-          <Card className="p-6">
-            <div className="space-y-4">
-              <h2 className="text-lg font-semibold">商品検索</h2>
-
-              <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-                <div className="space-y-2">
-                  <label className="text-sm font-medium">キーワード</label>
-                  <Input
-                    placeholder="検索キーワード"
-                    value={keyword}
-                    onChange={(e) => setKeyword(e.target.value)}
-                  />
-                </div>
-
-                <div className="space-y-2">
-                  <label className="text-sm font-medium">ショップコード</label>
-                  <Input
-                    placeholder="ショップコード"
-                    value={shopCode}
-                    onChange={(e) => setShopCode(e.target.value)}
-                  />
-                </div>
-
-                <div className="space-y-2">
-                  <label className="text-sm font-medium">ジャンルID</label>
-                  <Input
-                    placeholder="ジャンルID"
-                    value={genreId}
-                    onChange={(e) => setGenreId(e.target.value)}
-                  />
-                </div>
-              </div>
-
-              <Button
-                onClick={handleSearch}
-                disabled={loading}
-                className="w-full"
+      <main className="flex-1 overflow-y-auto">
+        <div className="container mx-auto p-6">
+          {/* トースト通知 */}
+          {toast && (
+            <div className="fixed top-4 left-1/2 -translate-x-1/2 z-50">
+              <div
+                className={`${
+                  toast.type === "success"
+                    ? "bg-gradient-to-r from-green-500 to-emerald-600"
+                    : toast.type === "error"
+                    ? "bg-gradient-to-r from-red-500 to-rose-600"
+                    : "bg-gradient-to-r from-yellow-500 to-orange-600"
+                } text-white px-6 py-4 rounded-lg shadow-2xl flex items-center gap-3 min-w-[320px] max-w-md animate-slide-in`}
               >
-                {loading ? "検索中..." : "商品を検索"}
+                <p className="flex-1 font-medium">{toast.message}</p>
+                <button
+                  onClick={() => setToast(null)}
+                  className="hover:bg-white/20 rounded-full p-1 transition-colors"
+                >
+                  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                  </svg>
+                </button>
+              </div>
+            </div>
+          )}
+
+          {/* ヘッダー */}
+          <div className="mb-6">
+            <div className="flex items-center justify-between mb-4">
+              <div>
+                <div className="flex items-center gap-2 mb-2">
+                  <svg className="w-6 h-6 text-red-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M16 11V7a4 4 0 00-8 0v4M5 9h14l1 12H4L5 9z" />
+                  </svg>
+                  <h1 className="text-2xl font-bold text-gray-900">{shopConfig.display_name}</h1>
+                  <span className="px-2 py-1 text-xs font-semibold rounded-full bg-red-100 text-red-800 border border-red-200">
+                    楽天市場
+                  </span>
+                </div>
+                <p className="text-gray-600">
+                  楽天市場から{shopConfig.display_name}の商品を検索・管理
+                </p>
+              </div>
+            </div>
+
+            {/* アクションボタン */}
+            <div className="flex items-center gap-3 mb-6">
+              <Button
+                onClick={handleUpdate}
+                disabled={updating}
+                className="flex items-center gap-2 bg-gradient-to-r from-blue-500 to-blue-600 hover:from-blue-600 hover:to-blue-700 text-white font-semibold shadow-lg hover:shadow-xl transition-all duration-200 disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                <svg className={`w-4 h-4 ${updating ? "animate-spin" : ""}`} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+                </svg>
+                {updating ? "実行中..." : "商品データ更新"}
               </Button>
             </div>
-          </Card>
+          </div>
 
           {/* 商品一覧 */}
-          <div>
-            <h2 className="text-xl font-semibold mb-4">商品一覧</h2>
-            <PaginatedProductTable
-              key={refreshKey}
-              shopFilter={brandConfig.displayName}
-            />
-          </div>
+          <ProductTable
+            key={refreshKey}
+            className="w-full"
+            shopFilter={shopConfig.display_name}
+          />
         </div>
       </main>
     </div>

--- a/src/app/rakuten/page.tsx
+++ b/src/app/rakuten/page.tsx
@@ -1,0 +1,495 @@
+"use client"
+
+/**
+ * 楽天ショップ管理ページ
+ * ショップの追加・編集・削除を行う
+ */
+
+import { useState, useEffect } from "react"
+import { MainLayout } from "@/components/layout/MainLayout"
+import { Card } from "@/components/ui/Card"
+import { Button } from "@/components/ui/Button"
+import { Input } from "@/components/ui/Input"
+import { Label } from "@/components/ui/Label"
+import { ShoppingBag, Plus, Edit, Trash2, X } from "lucide-react"
+import { supabase } from "@/lib/supabase"
+import type { Database } from "@/types/database"
+
+type RakutenShop = Database["public"]["Tables"]["rakuten_shops"]["Row"]
+type RakutenShopInsert = Database["public"]["Tables"]["rakuten_shops"]["Insert"]
+
+export default function RakutenManagementPage() {
+  const [shops, setShops] = useState<RakutenShop[]>([])
+  const [loading, setLoading] = useState(true)
+  const [saving, setSaving] = useState(false)
+  const [isFormOpen, setIsFormOpen] = useState(false)
+  const [editingShop, setEditingShop] = useState<RakutenShop | null>(null)
+  const [toast, setToast] = useState<{ message: string; type: "success" | "error" | "warning" } | null>(null)
+
+  // フォーム状態
+  const [formData, setFormData] = useState<RakutenShopInsert>({
+    shop_id: "",
+    display_name: "",
+    shop_code: "",
+    genre_id: "",
+    default_keyword: "",
+    is_active: true
+  })
+
+  // トースト表示関数
+  const showToast = (message: string, type: "success" | "error" | "warning") => {
+    setToast({ message, type })
+    setTimeout(() => setToast(null), 4000)
+  }
+
+  // ショップ一覧を読み込み
+  const loadShops = async () => {
+    setLoading(true)
+    const { data, error } = await supabase
+      .from("rakuten_shops")
+      .select("*")
+      .order("created_at", { ascending: false })
+
+    if (!error && data) {
+      setShops(data)
+    }
+    setLoading(false)
+  }
+
+  useEffect(() => {
+    loadShops()
+  }, [])
+
+  // フォームを開く
+  const openForm = (shop?: RakutenShop) => {
+    if (shop) {
+      setEditingShop(shop)
+      setFormData({
+        shop_id: shop.shop_id,
+        display_name: shop.display_name,
+        shop_code: shop.shop_code || "",
+        genre_id: shop.genre_id || "",
+        default_keyword: shop.default_keyword || "",
+        is_active: shop.is_active
+      })
+    } else {
+      setEditingShop(null)
+      setFormData({
+        shop_id: "",
+        display_name: "",
+        shop_code: "",
+        genre_id: "",
+        default_keyword: "",
+        is_active: true
+      })
+    }
+    setIsFormOpen(true)
+  }
+
+  // フォームを閉じる
+  const closeForm = () => {
+    setIsFormOpen(false)
+    setEditingShop(null)
+  }
+
+  // 保存処理
+  const handleSave = async () => {
+    // 基本バリデーション
+    if (!formData.shop_id || !formData.display_name) {
+      showToast("ショップIDと表示名は必須です", "error")
+      return
+    }
+
+    // 楽天API必須パラメータバリデーション（shopCodeとgenreIdのいずれかが必須）
+    if (!formData.shop_code && !formData.genre_id) {
+      showToast("楽天API：shopCodeまたはgenreIdのいずれかは必須です", "error")
+      return
+    }
+
+    setSaving(true)
+
+    try {
+      if (editingShop) {
+        // 更新
+        const updateData = {
+          shop_id: formData.shop_id,
+          display_name: formData.display_name,
+          shop_code: formData.shop_code || null,
+          genre_id: formData.genre_id || null,
+          default_keyword: formData.default_keyword || null,
+          is_active: formData.is_active ?? true
+        }
+
+        const { error } = await supabase
+          .from("rakuten_shops")
+          .update(updateData)
+          .eq("id", editingShop.id)
+
+        if (error) {
+          showToast(`更新に失敗しました: ${error.message}`, "error")
+          return
+        }
+
+        showToast("ショップ情報を更新しました", "success")
+      } else {
+        // 新規作成（商品データも取得）
+        const { error: insertError } = await supabase
+          .from("rakuten_shops")
+          .insert(formData as never)
+
+        if (insertError) {
+          showToast(`作成に失敗しました: ${insertError.message}`, "error")
+          return
+        }
+
+        // 楽天APIから商品データを取得
+        try {
+          const requestBody: Record<string, unknown> = {
+            shopCode: formData.shop_code,
+            genreId: formData.genre_id,
+            shopName: formData.display_name,
+            hits: 30,
+            page: 1
+          }
+
+          // キーワードが設定されている場合のみ追加
+          if (formData.default_keyword) {
+            requestBody.keyword = formData.default_keyword
+          }
+
+          const response = await fetch("/api/rakuten/search", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(requestBody)
+          })
+
+          const result = await response.json()
+
+          if (result.success) {
+            showToast(`ショップを作成し、${result.data.savedCount}件の商品データを取得しました`, "success")
+          } else {
+            showToast(`ショップは作成されましたが、商品データの取得に失敗しました`, "warning")
+          }
+        } catch {
+          showToast("ショップは作成されましたが、商品データの取得に失敗しました", "warning")
+        }
+      }
+
+      closeForm()
+      loadShops()
+      
+      // サイドバー更新イベントを発行
+      if (typeof window !== "undefined") {
+        window.dispatchEvent(new CustomEvent("rakuten:shop:updated"))
+      }
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  // 削除処理
+  const handleDelete = async (shop: RakutenShop) => {
+    if (!confirm(`「${shop.display_name}」を削除しますか？\n関連する商品データもすべて削除されます。`)) {
+      return
+    }
+
+    try {
+      // 1. 関連商品を削除
+      const { error: productsError } = await supabase
+        .from("products")
+        .delete()
+        .eq("shop_name", shop.display_name)
+
+      if (productsError) {
+        showToast(`商品データの削除に失敗しました: ${productsError.message}`, "error")
+        return
+      }
+
+      // 2. ショップを削除
+      const { error: shopError } = await supabase
+        .from("rakuten_shops")
+        .delete()
+        .eq("id", shop.id)
+
+      if (shopError) {
+        showToast(`ショップの削除に失敗しました: ${shopError.message}`, "error")
+        return
+      }
+
+      showToast(`「${shop.display_name}」とその商品データを削除しました`, "success")
+      loadShops()
+      
+      // サイドバー更新イベントを発行
+      if (typeof window !== "undefined") {
+        window.dispatchEvent(new CustomEvent("rakuten:shop:updated"))
+      }
+    } catch (error) {
+      showToast(`削除処理中にエラーが発生しました: ${error instanceof Error ? error.message : "不明なエラー"}`, "error")
+    }
+  }
+
+  return (
+    <MainLayout>
+      <div className="container mx-auto p-6">
+        {/* トースト通知 */}
+        {toast && (
+          <div className="fixed top-4 left-1/2 -translate-x-1/2 z-50">
+            <div
+              className={`${
+                toast.type === "success"
+                  ? "bg-gradient-to-r from-green-500 to-emerald-600"
+                  : toast.type === "error"
+                  ? "bg-gradient-to-r from-red-500 to-rose-600"
+                  : "bg-gradient-to-r from-yellow-500 to-orange-600"
+              } text-white px-6 py-4 rounded-lg shadow-2xl flex items-center gap-3 min-w-[320px] max-w-md animate-slide-in`}
+            >
+              <p className="flex-1 font-medium">{toast.message}</p>
+              <button
+                onClick={() => setToast(null)}
+                className="hover:bg-white/20 rounded-full p-1 transition-colors"
+              >
+                <X className="w-4 h-4" />
+              </button>
+            </div>
+          </div>
+        )}
+
+        {/* ヘッダー */}
+        <div className="mb-8">
+          <div className="flex items-center justify-between mb-4">
+            <div className="flex items-center gap-3">
+              <ShoppingBag className="w-8 h-8 text-red-600" />
+              <h1 className="text-3xl font-bold text-gray-900">楽天ショップ管理</h1>
+            </div>
+            <Button
+              onClick={() => openForm()}
+              className="flex items-center gap-2 bg-gradient-to-r from-green-500 to-emerald-600 hover:from-green-600 hover:to-emerald-700 text-white font-semibold shadow-lg hover:shadow-xl transition-all duration-200 border-2 border-green-400 px-6 py-2"
+            >
+              <Plus className="w-5 h-5" />
+              新規追加
+            </Button>
+          </div>
+          <p className="text-gray-600">
+            楽天市場のショップ（ブランド）を登録・管理します
+          </p>
+        </div>
+
+        {/* ショップ一覧テーブル */}
+        {loading ? (
+          <p className="text-gray-500">読み込み中...</p>
+        ) : shops.length === 0 ? (
+          <p className="text-gray-500">ショップが登録されていません</p>
+        ) : (
+          <Card className="overflow-hidden">
+            <div className="overflow-x-auto">
+              <table className="w-full">
+                <thead className="bg-gray-50 border-b border-gray-200">
+                  <tr>
+                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 tracking-wider">
+                      表示名
+                    </th>
+                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 tracking-wider">
+                      ショップID
+                    </th>
+                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 tracking-wider">
+                      shopCode
+                    </th>
+                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 tracking-wider">
+                      genreId
+                    </th>
+                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 tracking-wider">
+                      keyword
+                    </th>
+                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 tracking-wider">
+                      状態
+                    </th>
+                    <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 tracking-wider">
+                      操作
+                    </th>
+                  </tr>
+                </thead>
+                <tbody className="bg-white divide-y divide-gray-200">
+                  {shops.map((shop) => (
+                    <tr key={shop.id} className="hover:bg-gray-50 transition-colors">
+                      <td className="px-6 py-4 whitespace-nowrap">
+                        <div className="text-sm font-medium text-gray-900">{shop.display_name}</div>
+                      </td>
+                      <td className="px-6 py-4 whitespace-nowrap">
+                        <div className="text-sm text-gray-500">{shop.shop_id}</div>
+                      </td>
+                      <td className="px-6 py-4 whitespace-nowrap">
+                        <div className="text-sm text-gray-500">{shop.shop_code || "-"}</div>
+                      </td>
+                      <td className="px-6 py-4 whitespace-nowrap">
+                        <div className="text-sm text-gray-500">{shop.genre_id || "-"}</div>
+                      </td>
+                      <td className="px-6 py-4 whitespace-nowrap">
+                        <div className="text-sm text-gray-500">{shop.default_keyword || "-"}</div>
+                      </td>
+                      <td className="px-6 py-4 whitespace-nowrap">
+                        <span className={`px-2 py-1 inline-flex text-xs leading-5 font-semibold rounded-full ${
+                          shop.is_active
+                            ? "bg-green-100 text-green-800"
+                            : "bg-gray-100 text-gray-800"
+                        }`}>
+                          {shop.is_active ? "有効" : "無効"}
+                        </span>
+                      </td>
+                      <td className="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
+                        <div className="flex gap-2 justify-end">
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            onClick={() => openForm(shop)}
+                            className="flex items-center gap-1"
+                          >
+                            <Edit className="w-3 h-3" />
+                            編集
+                          </Button>
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            onClick={() => handleDelete(shop)}
+                            className="flex items-center gap-1 text-red-600 hover:bg-red-50"
+                          >
+                            <Trash2 className="w-3 h-3" />
+                            削除
+                          </Button>
+                        </div>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </Card>
+        )}
+
+        {/* フォームモーダル */}
+        {isFormOpen && (
+          <div
+            className="fixed inset-0 backdrop-blur-sm bg-white/30 flex items-center justify-center z-50 p-4"
+            onClick={closeForm}
+          >
+            <Card
+              className="w-full max-w-2xl max-h-[90vh] overflow-y-auto bg-white shadow-2xl border-2"
+              onClick={(e) => e.stopPropagation()}
+            >
+              <div className="p-6">
+                <div className="flex items-center justify-between mb-6">
+                  <h2 className="text-2xl font-bold">
+                    {editingShop ? "ショップを編集" : "ショップを追加"}
+                  </h2>
+                  <Button variant="ghost" size="sm" onClick={closeForm}>
+                    <X className="w-4 h-4" />
+                  </Button>
+                </div>
+
+                <div className="space-y-4">
+                  <div>
+                    <Label htmlFor="display_name">表示名（必須）</Label>
+                    <Input
+                      id="display_name"
+                      value={formData.display_name}
+                      onChange={(e) => setFormData({ ...formData, display_name: e.target.value })}
+                      placeholder="例: 無印良品"
+                    />
+                    <p className="text-xs text-gray-500 mt-1">
+                      サイドバーやヘッダーに表示される名前
+                    </p>
+                  </div>
+
+                  <div>
+                    <Label htmlFor="shop_id">ショップID（必須）</Label>
+                    <Input
+                      id="shop_id"
+                      value={formData.shop_id}
+                      onChange={(e) => setFormData({ ...formData, shop_id: e.target.value })}
+                      placeholder="例: muji, vt"
+                      disabled={!!editingShop}
+                    />
+                    <p className="text-xs text-gray-500 mt-1">
+                      URLパスに使用される一意の識別子（半角英数字推奨）
+                    </p>
+                  </div>
+
+                  <div>
+                    <Label htmlFor="shop_code">楽天API：shopCode（shopCodeかgenreIdのいずれか必須）</Label>
+                    <Input
+                      id="shop_code"
+                      value={formData.shop_code || ""}
+                      onChange={(e) => setFormData({ ...formData, shop_code: e.target.value })}
+                      placeholder="楽天API用のショップコード"
+                    />
+                  </div>
+
+                  <div>
+                    <Label htmlFor="genre_id">楽天API：genreId（shopCodeかgenreIdのいずれか必須）</Label>
+                    <Input
+                      id="genre_id"
+                      value={formData.genre_id || ""}
+                      onChange={(e) => setFormData({ ...formData, genre_id: e.target.value })}
+                      placeholder="楽天API用のジャンルID"
+                    />
+                  </div>
+
+                  <div>
+                    <Label htmlFor="default_keyword">楽天API：keyword（任意）</Label>
+                    <Input
+                      id="default_keyword"
+                      value={formData.default_keyword || ""}
+                      onChange={(e) => setFormData({ ...formData, default_keyword: e.target.value })}
+                      placeholder="例: 無印良品"
+                    />
+                    <p className="text-xs text-gray-500 mt-1">
+                      商品検索時のデフォルトキーワード（ブランド名など）
+                    </p>
+                  </div>
+
+                  <div className="flex items-center gap-2">
+                    <input
+                      type="checkbox"
+                      id="is_active"
+                      checked={formData.is_active}
+                      onChange={(e) => setFormData({ ...formData, is_active: e.target.checked })}
+                      className="w-4 h-4"
+                    />
+                    <Label htmlFor="is_active">有効にする</Label>
+                  </div>
+                </div>
+
+                <div className="flex gap-3 mt-6">
+                  <Button
+                    onClick={handleSave}
+                    disabled={saving}
+                    className="flex-1 bg-gradient-to-r from-blue-500 to-blue-600 hover:from-blue-600 hover:to-blue-700 text-white font-semibold shadow-lg hover:shadow-xl transition-all duration-200 border-2 border-blue-400 disabled:opacity-50 disabled:cursor-not-allowed"
+                  >
+                    {saving ? (
+                      <span className="flex items-center gap-2">
+                        <svg className="animate-spin h-4 w-4" viewBox="0 0 24 24">
+                          <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" fill="none" />
+                          <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
+                        </svg>
+                        処理中...
+                      </span>
+                    ) : (
+                      editingShop ? "更新" : "作成"
+                    )}
+                  </Button>
+                  <Button
+                    variant="outline"
+                    onClick={closeForm}
+                    disabled={saving}
+                    className="flex-1 border-2 border-gray-300 hover:border-gray-400 hover:bg-gray-50 font-semibold transition-all duration-200 disabled:opacity-50 disabled:cursor-not-allowed"
+                  >
+                    キャンセル
+                  </Button>
+                </div>
+              </div>
+            </Card>
+          </div>
+        )}
+      </div>
+    </MainLayout>
+  )
+}

--- a/src/components/ui/Toast.tsx
+++ b/src/components/ui/Toast.tsx
@@ -1,0 +1,54 @@
+"use client"
+
+import { useEffect } from "react"
+import { CheckCircle, XCircle, AlertCircle, X } from "lucide-react"
+
+export type ToastType = "success" | "error" | "warning"
+
+interface ToastProps {
+  message: string
+  type: ToastType
+  onClose: () => void
+  duration?: number
+}
+
+export function Toast({ message, type, onClose, duration = 4000 }: ToastProps) {
+  useEffect(() => {
+    const timer = setTimeout(onClose, duration)
+    return () => clearTimeout(timer)
+  }, [duration, onClose])
+
+  const styles = {
+    success: {
+      bg: "bg-gradient-to-r from-green-500 to-emerald-600",
+      icon: <CheckCircle className="w-5 h-5" />,
+    },
+    error: {
+      bg: "bg-gradient-to-r from-red-500 to-rose-600",
+      icon: <XCircle className="w-5 h-5" />,
+    },
+    warning: {
+      bg: "bg-gradient-to-r from-yellow-500 to-orange-600",
+      icon: <AlertCircle className="w-5 h-5" />,
+    },
+  }
+
+  const style = styles[type]
+
+  return (
+    <div
+      className={`${style.bg} text-white px-6 py-4 rounded-lg shadow-2xl flex items-center gap-3 min-w-[320px] max-w-md animate-slide-in`}
+      role="alert"
+    >
+      {style.icon}
+      <p className="flex-1 font-medium">{message}</p>
+      <button
+        onClick={onClose}
+        className="hover:bg-white/20 rounded-full p-1 transition-colors"
+        aria-label="閉じる"
+      >
+        <X className="w-4 h-4" />
+      </button>
+    </div>
+  )
+}

--- a/src/components/ui/ToastContainer.tsx
+++ b/src/components/ui/ToastContainer.tsx
@@ -1,0 +1,53 @@
+"use client"
+
+import { createContext, useContext, useState, useCallback, ReactNode } from "react"
+import { Toast, ToastType } from "./Toast"
+
+interface ToastMessage {
+  id: string
+  message: string
+  type: ToastType
+}
+
+interface ToastContextType {
+  showToast: (message: string, type: ToastType) => void
+}
+
+const ToastContext = createContext<ToastContextType | undefined>(undefined)
+
+export function ToastProvider({ children }: { children: ReactNode }) {
+  const [toasts, setToasts] = useState<ToastMessage[]>([])
+
+  const showToast = useCallback((message: string, type: ToastType) => {
+    const id = Math.random().toString(36).substring(7)
+    setToasts((prev) => [...prev, { id, message, type }])
+  }, [])
+
+  const removeToast = useCallback((id: string) => {
+    setToasts((prev) => prev.filter((toast) => toast.id !== id))
+  }, [])
+
+  return (
+    <ToastContext.Provider value={{ showToast }}>
+      {children}
+      <div className="fixed top-4 right-4 z-50 flex flex-col gap-2">
+        {toasts.map((toast) => (
+          <Toast
+            key={toast.id}
+            message={toast.message}
+            type={toast.type}
+            onClose={() => removeToast(toast.id)}
+          />
+        ))}
+      </div>
+    </ToastContext.Provider>
+  )
+}
+
+export function useToast() {
+  const context = useContext(ToastContext)
+  if (!context) {
+    throw new Error("useToast must be used within ToastProvider")
+  }
+  return context
+}

--- a/src/lib/events.ts
+++ b/src/lib/events.ts
@@ -1,0 +1,26 @@
+/**
+ * カスタムイベント定義
+ * コンポーネント間でイベントを送信するためのヘルパー関数
+ */
+
+export const RAKUTEN_SHOP_UPDATED = "rakuten:shop:updated"
+
+/**
+ * 楽天ショップ更新イベントを発行
+ */
+export function emitRakutenShopUpdated() {
+  if (typeof window !== "undefined") {
+    window.dispatchEvent(new CustomEvent(RAKUTEN_SHOP_UPDATED))
+  }
+}
+
+/**
+ * 楽天ショップ更新イベントをリッスン
+ */
+export function onRakutenShopUpdated(callback: () => void) {
+  if (typeof window !== "undefined") {
+    window.addEventListener(RAKUTEN_SHOP_UPDATED, callback)
+    return () => window.removeEventListener(RAKUTEN_SHOP_UPDATED, callback)
+  }
+  return () => {}
+}

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -199,6 +199,41 @@ export interface Database {
           updated_at?: string
         }
       }
+      rakuten_shops: {
+        Row: {
+          id: string
+          shop_id: string
+          display_name: string
+          shop_code: string | null
+          genre_id: string | null
+          default_keyword: string | null
+          is_active: boolean
+          created_at: string
+          updated_at: string
+        }
+        Insert: {
+          id?: string
+          shop_id: string
+          display_name: string
+          shop_code?: string | null
+          genre_id?: string | null
+          default_keyword?: string | null
+          is_active?: boolean
+          created_at?: string
+          updated_at?: string
+        }
+        Update: {
+          id?: string
+          shop_id?: string
+          display_name?: string
+          shop_code?: string | null
+          genre_id?: string | null
+          default_keyword?: string | null
+          is_active?: boolean
+          created_at?: string
+          updated_at?: string
+        }
+      }
     }
     Views: {
       [_ in never]: never

--- a/supabase/migrations/20251005000000_create_rakuten_shops.sql
+++ b/supabase/migrations/20251005000000_create_rakuten_shops.sql
@@ -1,0 +1,31 @@
+-- 楽天ショップ設定テーブル
+CREATE TABLE IF NOT EXISTS rakuten_shops (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  shop_id TEXT NOT NULL UNIQUE, -- 内部識別用ID（URLパスに使用）
+  display_name TEXT NOT NULL, -- サイドバー・ヘッダー表示名
+  shop_code TEXT, -- 楽天ショップコード
+  genre_id TEXT, -- 楽天ジャンルID
+  default_keyword TEXT, -- デフォルト検索キーワード（ブランド名など）
+  is_active BOOLEAN NOT NULL DEFAULT true, -- アクティブフラグ
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- インデックス作成
+CREATE INDEX idx_rakuten_shops_shop_id ON rakuten_shops(shop_id);
+CREATE INDEX idx_rakuten_shops_is_active ON rakuten_shops(is_active);
+
+-- updated_at自動更新トリガー
+CREATE TRIGGER update_rakuten_shops_updated_at
+  BEFORE UPDATE ON rakuten_shops
+  FOR EACH ROW
+  EXECUTE FUNCTION update_updated_at_column();
+
+-- コメント追加
+COMMENT ON TABLE rakuten_shops IS '楽天ショップ（ブランド）の設定情報を管理するテーブル';
+COMMENT ON COLUMN rakuten_shops.shop_id IS '内部識別用ID（URLパスに使用、例: muji, vt）';
+COMMENT ON COLUMN rakuten_shops.display_name IS 'サイドバーやヘッダーに表示する名前';
+COMMENT ON COLUMN rakuten_shops.shop_code IS '楽天API用のショップコード';
+COMMENT ON COLUMN rakuten_shops.genre_id IS '楽天API用のジャンルID';
+COMMENT ON COLUMN rakuten_shops.default_keyword IS 'デフォルト検索キーワード（ブランド名など）';
+COMMENT ON COLUMN rakuten_shops.is_active IS 'アクティブ状態（無効化したショップは非表示）';

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -67,10 +67,15 @@ const config: Config = {
           from: { height: "var(--radix-accordion-content-height)" },
           to: { height: "0" },
         },
+        "slide-in": {
+          from: { transform: "translateX(100%)", opacity: "0" },
+          to: { transform: "translateX(0)", opacity: "1" },
+        },
       },
       animation: {
         "accordion-down": "accordion-down 0.2s ease-out",
         "accordion-up": "accordion-up 0.2s ease-out",
+        "slide-in": "slide-in 0.3s ease-out",
       },
     },
   },


### PR DESCRIPTION
## 概要
楽天ショップページの商品データ更新機能における重複判定の不具合と、ショップ設定の編集機能を修正しました。

## 変更内容
### 重複判定の修正
- 414 Request-URI Too Largeエラーを回避するため、商品URLを50件ずつに分割してクエリ
- 商品URLベースの重複判定を実装
- 価格変動検出と更新処理を追加
- 全ページの商品データを取得するように改善

### ショップ設定編集機能の修正
- 更新時に明示的なフィールド指定を実装
- formDataを直接渡す代わりにupdateDataオブジェクトを作成
- 空文字をnullに変換して正しくデータベース更新

### UI改善
- 楽天ブランドページのボタン名を「スクレイピング」から「商品データ更新」に変更
- トースト通知コンポーネントを実装
- サイドバーに楽天ショップ動的メニューを追加

### データベース
- rakuten_shopsテーブルのマイグレーションを作成
- 型定義を追加

## テスト結果
```
取得した商品数: 329
既存商品数: 973
Mapに登録された既存商品数: 300
新規商品数: 2
価格更新対象数: 0
スキップ数: 327
```

## チェックリスト
- [x] TypeScriptエラーなし
- [x] リントエラーなし
- [x] 動作確認済み
- [x] ドキュメント更新不要

Close #63